### PR TITLE
If resubscribe, replace the message handler with new user callback

### DIFF
--- a/MQTTClient/src/MQTTClient.h
+++ b/MQTTClient/src/MQTTClient.h
@@ -750,7 +750,8 @@ int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, MAX_MESSAGE_HANDLERS>::su
         {
             for (int i = 0; i < MAX_MESSAGE_HANDLERS; ++i)
             {
-                if (messageHandlers[i].topicFilter == 0)
+                if ((messageHandlers[i].topicFilter == 0) 
+		    || (strcmp(messageHandlers[i].topicFilter, topicFilter) == 0))
                 {
                     messageHandlers[i].topicFilter = topicFilter;
                     messageHandlers[i].fp.attach(messageHandler);


### PR DESCRIPTION
This pull request is to fix issue https://github.com/eclipse/paho.mqtt.embedded-c/issues/49

If the application resubscribe to the same topic filter, replace the existing message handler entry with the new user callback function.

Signed-off-by: miketran78727 <miketran@us.ibm.com>