### PR TITLE
return FAILURE when readPacket fails by unexpected network I/O error.

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -223,9 +223,9 @@ exit:
 int cycle(MQTTClient* c, Timer* timer)
 {
     // read the socket, see what work is due
-    unsigned short packet_type = readPacket(c, timer);
-    if (packet_type == 0)
-        return FAILURE; // no more data to read, unrecoverable
+    int packet_type = readPacket(c, timer);
+    if (packet_type <= 0)
+        return FAILURE; // no more data to read, unrecoverable. Or read packet fails due to unexpected network error
 
     int len = 0,
         rc = SUCCESS;


### PR DESCRIPTION
network I/O could return FAILURE(-1) when it loses network connection or OS layer failure such as memory allocation failure.