### PR TITLE
Added new transport example and samples to test it.

### DIFF
--- a/MQTTPacket/samples/baremetalserial/build
+++ b/MQTTPacket/samples/baremetalserial/build
@@ -1,0 +1,3 @@
+gcc -g -Wall pub0sub1_nb.c transport.c -I ../../src ../../src/MQTTConnectClient.c ../../src/MQTTSerializePublish.c ../../src/MQTTPacket.c ../../src/MQTTSubscribeClient.c -o pub0sub1_nb ../../src/MQTTDeserializePublish.c ../../src/MQTTConnectServer.c ../../src/MQTTSubscribeServer.c ../../src/MQTTUnsubscribeServer.c ../../src/MQTTUnsubscribeClient.c
+gcc -g -Wall ping_nb.c transport.c -I ../../src ../../src/MQTTConnectClient.c ../../src/MQTTPacket.c -o ping_nb
+

--- a/MQTTPacket/samples/baremetalserial/ping_nb.c
+++ b/MQTTPacket/samples/baremetalserial/ping_nb.c
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Sergio R. Caprile
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "MQTTPacket.h"
+#include "transport.h"
+
+#define KEEPALIVE_INTERVAL 20
+
+/* This is to get a timebase in seconds to test the sample */
+#include <time.h>
+time_t old_t;
+void start_ping_timer(void)
+{
+	time(&old_t);
+	old_t += KEEPALIVE_INTERVAL/2 + 1;
+}
+
+int time_to_ping(void)
+{
+time_t t;
+
+	time(&t);
+	if(t >= old_t)
+	  	return 1;
+	return 0;
+}
+
+/* This is in order to get an asynchronous signal to stop the sample,
+as the code loops waiting for msgs on the subscribed topic.
+Your actual code will depend on your hw and approach, but this sample can be
+run on Linux so debugging of the non-hardware specific bare metal code is easier.
+See at bottom of file for details */
+#include <signal.h>
+
+int toStop = 0;
+
+void stop_init(void);
+/* */
+
+/* Same as above, we provide a set of functions to test/debug on a friendlier system;
+the init() and  close() actions on the serial are just for this, you will probably
+handle this on whatever handles your media in your application */
+void sampleserial_init(void);
+void sampleserial_close(void);
+int samplesend(unsigned char *address, unsigned int bytes);
+int samplerecv(unsigned char *address, unsigned int maxbytes);
+/* */
+
+/* You will use your hardware specifics here, see transport.h. */
+static transport_iofunctions_t iof = {samplesend, samplerecv};
+
+enum states { IDLE, SENDPING, GETPONG };
+
+int main(int argc, char *argv[])
+{
+	MQTTPacket_connectData data = MQTTPacket_connectData_initializer;
+	int rc = 0;
+	int mysock = 0;
+	unsigned char buf[200];
+	int buflen = sizeof(buf);
+	int len = 0;
+	MQTTTransport mytransport;
+	int state;
+
+	stop_init();
+	sampleserial_init();
+
+	mysock = transport_open(&iof);
+	if(mysock < 0)
+		return mysock;
+	/* You will (or already are) 'somehow' connect(ed) to host:port via your hardware specifics. E.g.:
+		you have a serial (RS-232/UART) link
+		you have a cell modem and you issue your AT+ magic
+		you have some TCP/IP which is not lwIP (nor a full-fledged socket compliant one)
+		 and you TCP connect
+	*/
+
+	mytransport.sck = &mysock;
+	mytransport.getfn = transport_getdatanb;
+	mytransport.state = 0;
+	data.clientID.cstring = "me";
+	data.keepAliveInterval = KEEPALIVE_INTERVAL;
+	data.cleansession = 1;
+	data.username.cstring = "testuser";
+	data.password.cstring = "testpassword";
+
+	len = MQTTSerialize_connect(buf, buflen, &data);
+	/* This one blocks until it finishes sending, you will probably not want this in real life,
+	in such a case replace this call by a scheme similar to the one you'll see in the main loop */
+	rc = transport_sendPacketBuffer(mysock, buf, len);
+
+	printf("Sent MQTT connect\n");
+	/* wait for connack */
+	do {
+		int frc;
+		if ((frc=MQTTPacket_readnb(buf, buflen, &mytransport)) == CONNACK){
+			unsigned char sessionPresent, connack_rc;
+			if (MQTTDeserialize_connack(&sessionPresent, &connack_rc, buf, buflen) != 1 || connack_rc != 0){
+				printf("Unable to connect, return code %d\n", connack_rc);
+				goto exit;
+			}
+			break;
+		}
+		else if (frc == -1)
+			goto exit;
+	} while (1); /* handle timeouts here */
+
+	printf("MQTT connected\n");
+	start_ping_timer();
+	state = IDLE;
+	while (!toStop)	{
+		switch(state){
+		case IDLE:
+			if(time_to_ping()){
+				len = MQTTSerialize_pingreq(buf, buflen);
+				transport_sendPacketBuffernb_start(mysock, buf, len);
+				state = SENDPING;
+			}
+			break;
+		case SENDPING:
+			switch(transport_sendPacketBuffernb(mysock)){
+			case TRANSPORT_DONE:
+				printf("Ping...");
+				start_ping_timer();
+				state = GETPONG;
+				break;
+			case TRANSPORT_ERROR:
+				/* handle any I/O errors here */
+				goto exit;
+				break;
+			case TRANSPORT_AGAIN:
+			default:
+				/* handle timeouts here, not probable unless there is a hardware problem */
+				break;
+			}
+			break;
+		case GETPONG:
+			if((rc=MQTTPacket_readnb(buf, buflen, &mytransport)) == PINGRESP){
+				printf("Pong\n");
+				start_ping_timer();
+				state = IDLE;
+			} else if(rc == -1){
+				/* handle I/O errors here */
+				printf("OOPS\n");
+				goto exit;
+			}	/* handle timeouts here */
+			break;
+		}
+	}
+
+	printf("disconnecting\n");
+	len = MQTTSerialize_disconnect(buf, buflen);
+	/* Same blocking related stuff here */
+	rc = transport_sendPacketBuffer(mysock, buf, len);
+
+exit:
+	transport_close(mysock);
+	
+	sampleserial_close();
+	return 0;
+}
+
+
+/* To stop the sample */
+void cfinish(int sig)
+{
+	signal(SIGINT, NULL);
+	toStop = 1;
+}
+
+void stop_init(void)
+{
+	signal(SIGINT, cfinish);
+	signal(SIGTERM, cfinish);
+}
+
+/* Serial hack:
+Simulate serial transfers on an established TCP connection
+ */
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h> 
+#include <fcntl.h>
+
+static int sockfd;
+
+void sampleserial_init(void)
+{
+struct sockaddr_in serv_addr;
+
+
+	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+	  perror(NULL);
+	  exit(2);
+	}
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_addr.s_addr = inet_addr("198.41.30.241");
+	serv_addr.sin_port = htons(1883);
+	if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+		printf("ERROR connecting\n");
+		exit(-1);
+	}
+	printf("- TCP Connected to Eclipse\n");
+        /* set to non-blocking */
+	fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK);
+}
+
+void sampleserial_close(void)
+{
+	close(sockfd);
+}
+
+int samplesend(unsigned char *address, unsigned int bytes)
+{
+int len;
+
+	if(rand() > (RAND_MAX/2))	// 50% probability of being busy
+		return 0;
+	if(rand() > (RAND_MAX/2)){	// 50% probability of sending half the requested data (no room in buffer)
+		if(bytes > 1)
+			bytes /= 2;
+	}
+	if((len = write(sockfd, address, bytes)) >= 0)
+		return len;
+	if(errno == EAGAIN)
+		return 0;
+	return -1;
+}
+
+int samplerecv(unsigned char *address, unsigned int maxbytes)
+{
+int len;
+
+	if(rand() > (RAND_MAX/2))	// 50% probability of no data
+		return 0;
+	if(rand() > (RAND_MAX/2)){	// 50% probability of getting half the requested data (not arrived yet)
+		if(maxbytes > 1){
+			maxbytes /= 2;
+		}
+	}
+	if((len = read(sockfd, address, maxbytes)) >= 0)
+		return len;
+	if(errno == EAGAIN)
+		return 0;
+	return -1;
+}
+

--- a/MQTTPacket/samples/baremetalserial/pub0sub1_nb.c
+++ b/MQTTPacket/samples/baremetalserial/pub0sub1_nb.c
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - port to the bare metal environment
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "MQTTPacket.h"
+#include "transport.h"
+
+/* This is in order to get an asynchronous signal to stop the sample,
+as the code loops waiting for msgs on the subscribed topic.
+Your actual code will depend on your hw and approach, but this sample can be
+run on Linux so debugging of the non-hardware specific bare metal code is easier.
+See at bottom of file for details */
+#include <signal.h>
+
+int toStop = 0;
+
+void stop_init(void);
+/* */
+
+/* Same as above, we provide a set of functions to test/debug on a friendlier system;
+the init() and  close() actions on the serial are just for this, you will probably
+handle this on whatever handles your media in your application */
+void sampleserial_init(void);
+void sampleserial_close(void);
+int samplesend(unsigned char *address, unsigned int bytes);
+int samplerecv(unsigned char *address, unsigned int maxbytes);
+/* */
+
+/* You will use your hardware specifics here, see transport.h. */
+static transport_iofunctions_t iof = {samplesend, samplerecv};
+
+enum states { READING, PUBLISHING };
+
+int main(int argc, char *argv[])
+{
+	MQTTPacket_connectData data = MQTTPacket_connectData_initializer;
+	int rc = 0;
+	int mysock = 0;
+	unsigned char buf[200];
+	int buflen = sizeof(buf);
+	int msgid = 1;
+	MQTTString topicString = MQTTString_initializer;
+	int req_qos = 0;
+	char* payload = "mypayload";
+	int payloadlen = strlen(payload);
+	int len = 0;
+	MQTTTransport mytransport;
+	int state = READING;
+
+	stop_init();
+	sampleserial_init();
+
+	mysock = transport_open(&iof);
+	if(mysock < 0)
+		return mysock;
+	/* You will (or already are) 'somehow' connect(ed) to host:port via your hardware specifics. E.g.:
+		you have a serial (RS-232/UART) link
+		you have a cell modem and you issue your AT+ magic
+		you have some TCP/IP which is not lwIP (nor a full-fledged socket compliant one)
+		 and you TCP connect
+	*/
+
+	mytransport.sck = &mysock;
+	mytransport.getfn = transport_getdatanb;
+	mytransport.state = 0;
+	data.clientID.cstring = "me";
+	data.keepAliveInterval = 20;
+	data.cleansession = 1;
+	data.username.cstring = "testuser";
+	data.password.cstring = "testpassword";
+
+	len = MQTTSerialize_connect(buf, buflen, &data);
+	/* This one blocks until it finishes sending, you will probably not want this in real life,
+	in such a case replace this call by a scheme similar to the one you'll see in the main loop */
+	rc = transport_sendPacketBuffer(mysock, buf, len);
+
+	printf("Sent MQTT connect\n");
+	/* wait for connack */
+	do {
+		int frc;
+		if ((frc=MQTTPacket_readnb(buf, buflen, &mytransport)) == CONNACK){
+			unsigned char sessionPresent, connack_rc;
+			if (MQTTDeserialize_connack(&sessionPresent, &connack_rc, buf, buflen) != 1 || connack_rc != 0){
+				printf("Unable to connect, return code %d\n", connack_rc);
+				goto exit;
+			}
+			break;
+		}
+		else if (frc == -1)
+			goto exit;
+	} while (1); /* handle timeouts here */
+
+	printf("MQTT connected\n");
+	/* subscribe */
+	topicString.cstring = "substopic";
+	len = MQTTSerialize_subscribe(buf, buflen, 0, msgid, 1, &topicString, &req_qos);
+
+	/* This is equivalent to the one above, but using the non-blocking functions. You will probably not want this in real life,
+	in such a case replace this call by a scheme similar to the one you'll see in the main loop */
+	transport_sendPacketBuffernb_start(mysock, buf, len);
+	while((rc=transport_sendPacketBuffernb(mysock)) != TRANSPORT_DONE);
+	do {
+		int frc;
+		if ((frc=MQTTPacket_readnb(buf, buflen, &mytransport)) == SUBACK){ /* wait for suback */
+			unsigned short submsgid;
+			int subcount;
+			int granted_qos;
+
+			rc = MQTTDeserialize_suback(&submsgid, 1, &subcount, &granted_qos, buf, buflen);
+			if (granted_qos != 0){
+				printf("granted qos != 0, %d\n", granted_qos);
+				goto exit;
+			}
+			break;
+		}
+		else if (frc == -1)
+			goto exit;
+	} while (1); /* handle timeouts here */
+	printf("Subscribed\n");
+
+	/* loop getting msgs on subscribed topic */
+	topicString.cstring = "pubtopic";
+	state = READING;
+	while (!toStop)	{
+		/* do other stuff here */
+		switch(state){
+		case READING:
+			if((rc=MQTTPacket_readnb(buf, buflen, &mytransport)) == PUBLISH){
+				unsigned char dup;
+				int qos;
+				unsigned char retained;
+				unsigned short msgid;
+				int payloadlen_in;
+				unsigned char* payload_in;
+				int rc;
+				MQTTString receivedTopic;
+	
+				rc = MQTTDeserialize_publish(&dup, &qos, &retained, &msgid, &receivedTopic,
+						&payload_in, &payloadlen_in, buf, buflen);
+				printf("message arrived %.*s\n", payloadlen_in, payload_in);
+				printf("publishing reading\n");
+				state = PUBLISHING;
+				len = MQTTSerialize_publish(buf, buflen, 0, 0, 0, 0, topicString, (unsigned char*)payload, payloadlen);
+				transport_sendPacketBuffernb_start(mysock, buf, len);
+			} else if(rc == -1){
+				/* handle I/O errors here */
+				goto exit;
+			}	/* handle timeouts here */
+			break;
+		case PUBLISHING:
+			switch(transport_sendPacketBuffernb(mysock)){
+			case TRANSPORT_DONE:
+				printf("Published\n");
+				state = READING;
+				break;
+			case TRANSPORT_ERROR:
+				/* handle any I/O errors here */
+				goto exit;
+				break;
+			case TRANSPORT_AGAIN:
+			default:
+				/* handle timeouts here, not probable unless there is a hardware problem */
+				break;
+			}
+			break;
+		}
+	}
+
+	printf("disconnecting\n");
+	len = MQTTSerialize_disconnect(buf, buflen);
+	/* Same blocking related stuff here */
+	rc = transport_sendPacketBuffer(mysock, buf, len);
+
+exit:
+	transport_close(mysock);
+	
+	sampleserial_close();
+	return 0;
+}
+
+
+/* To stop the sample */
+void cfinish(int sig)
+{
+	signal(SIGINT, NULL);
+	toStop = 1;
+}
+
+void stop_init(void)
+{
+	signal(SIGINT, cfinish);
+	signal(SIGTERM, cfinish);
+}
+
+/* Serial hack:
+Simulate serial transfers on an established TCP connection
+ */
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h> 
+#include <fcntl.h>
+
+static int sockfd;
+
+void sampleserial_init(void)
+{
+struct sockaddr_in serv_addr;
+
+
+	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+	  perror(NULL);
+	  exit(2);
+	}
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_addr.s_addr = inet_addr("198.41.30.241");
+	serv_addr.sin_port = htons(1883);
+	if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+		printf("ERROR connecting\n");
+		exit(-1);
+	}
+	printf("- TCP Connected to Eclipse\n");
+        /* set to non-blocking */
+	fcntl(sockfd, F_SETFL, fcntl(sockfd, F_GETFL) | O_NONBLOCK);
+}
+
+void sampleserial_close(void)
+{
+	close(sockfd);
+}
+
+int samplesend(unsigned char *address, unsigned int bytes)
+{
+int len;
+
+	if(rand() > (RAND_MAX/2))	// 50% probability of being busy
+		return 0;
+	if(rand() > (RAND_MAX/2)){	// 50% probability of sending half the requested data (no room in buffer)
+		if(bytes > 1)
+			bytes /= 2;
+	}
+	if((len = write(sockfd, address, bytes)) >= 0)
+		return len;
+	if(errno == EAGAIN)
+		return 0;
+	return -1;
+}
+
+int samplerecv(unsigned char *address, unsigned int maxbytes)
+{
+int len;
+
+	if(rand() > (RAND_MAX/2))	// 50% probability of no data
+		return 0;
+	if(rand() > (RAND_MAX/2)){	// 50% probability of getting half the requested data (not arrived yet)
+		if(maxbytes > 1){
+			maxbytes /= 2;
+		}
+	}
+	if((len = read(sockfd, address, maxbytes)) >= 0)
+		return len;
+	if(errno == EAGAIN)
+		return 0;
+	return -1;
+}
+

--- a/MQTTPacket/samples/baremetalserial/transport.c
+++ b/MQTTPacket/samples/baremetalserial/transport.c
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - port to the bare metal environment and serial media specifics
+ *******************************************************************************/
+
+/** By the way, this is a nice bare bones example, easier to expand to whatever non-OS
+media you might have */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "transport.h"
+
+/**
+This simple low-level implementation assumes a single connection for a single thread. Thus, single static
+variables are used for that connection.
+On other scenarios, you might want to put all these variables into a structure and index via the 'sock'
+parameter, as some functions show in the comments
+The blocking rx function is not supported.
+If you plan on writing one, take into account that the current implementation of
+MQTTPacket_read() has a function pointer for a function call to get the data to a buffer, but no provisions
+to know the caller or other indicator (the socket id): int (*getfn)(unsigned char*, int)
+*/
+static transport_iofunctions_t *io = NULL;
+static unsigned char *from = NULL;		// to keep track of data sending
+static int howmany;				// ditto
+
+
+void transport_sendPacketBuffernb_start(int sock, unsigned char* buf, int buflen)
+{
+	from = buf;			// from[sock] or mystruct[sock].from
+	howmany = buflen;		// myhowmany[sock] or mystruct[sock].howmany
+}
+
+int transport_sendPacketBuffernb(int sock)
+{
+transport_iofunctions_t *myio = io;	// io[sock] or mystruct[sock].io
+int len;
+
+	/* you should have called open() with a valid pointer to a valid struct and 
+	called sendPacketBuffernb_start with a valid buffer, before calling this */
+	assert((myio != NULL) && (myio->send != NULL) && (from != NULL));
+	if((len = myio->send(from, howmany)) > 0){
+		from += len;
+		if((howmany -= len) <= 0){
+			return TRANSPORT_DONE;
+		}
+	} else if(len < 0){
+		return TRANSPORT_ERROR;
+	}
+	return TRANSPORT_AGAIN;
+}
+
+int transport_sendPacketBuffer(int sock, unsigned char* buf, int buflen)
+{
+int rc;
+
+	transport_sendPacketBuffernb_start(sock, buf, buflen);
+	while((rc=transport_sendPacketBuffernb(sock)) == TRANSPORT_AGAIN){
+		/* this is unlikely to loop forever unless there is a hardware problem */
+	}
+	if(rc == TRANSPORT_DONE){
+		return buflen;
+	}
+	return TRANSPORT_ERROR;
+}
+
+
+int transport_getdata(unsigned char* buf, int count)
+{
+	assert(0);		/* This function is NOT supported, it is just here to tease you */
+	return TRANSPORT_ERROR;	/* nah, it is here for similarity with other transport examples */
+}
+
+int transport_getdatanb(void *sck, unsigned char* buf, int count)
+{
+//int sock = *((int *)sck); 		/* sck: pointer to whatever the system may use to identify the transport */
+transport_iofunctions_t *myio = io;	// io[sock] or mystruct[sock].io
+int len;
+	
+	/* you should have called open() with a valid pointer to a valid struct before calling this */
+	assert((myio != NULL) && (myio->recv != NULL));
+	/* this call will return immediately if no bytes, or return whatever outstanding bytes we have,
+	 upto count */
+	if((len = myio->recv(buf, count)) >= 0)
+		return len;
+	return TRANSPORT_ERROR;
+}
+
+/**
+return >=0 for a connection descriptor, <0 for an error code
+*/
+int transport_open(transport_iofunctions_t *thisio)
+{
+int idx=0;	// for multiple connections, you might, basically turn myio into myio[MAX_CONNECTIONS],
+
+	//if((idx=assignidx()) >= MAX_CONNECTIONS)	// somehow assign an index,
+	//	return TRANSPORT_ERROR;
+	io = thisio;					// store myio[idx] = thisio, or mystruct[idx].io = thisio, 
+	return idx;					// and return the index used
+}
+
+int transport_close(int sock)
+{
+int rc=TRANSPORT_DONE;
+
+	return rc;
+}

--- a/MQTTPacket/samples/baremetalserial/transport.h
+++ b/MQTTPacket/samples/baremetalserial/transport.h
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - media specifics, nice api doc :^)
+ *******************************************************************************/
+
+typedef struct {
+	int (*send)(unsigned char *address, unsigned int bytes); 	///< pointer to function to send 'bytes' bytes, returns the actual number of bytes sent
+	int (*recv)(unsigned char *address, unsigned int maxbytes); 	///< pointer to function to receive upto 'maxbytes' bytes, returns the actual number of bytes copied
+} transport_iofunctions_t;
+
+#define TRANSPORT_DONE	1
+#define TRANSPORT_AGAIN	0
+#define TRANSPORT_ERROR	-1
+/**
+@note Blocks until requested buflen is sent
+*/
+int transport_sendPacketBuffer(int sock, unsigned char* buf, int buflen);
+/**
+@note Blocks until requested count is received, as MQTTPacket_read() expects
+@warning This function is not supported (not implemented)
+@warning unless you provide a timeout, this function can block forever. Socket based systems do have
+a built in timeout, if your system can provide this, do modify this function, otherwise use getdatanb() instead
+@returns number of bytes read
+*/
+int transport_getdata(unsigned char* buf, int count);
+
+/**
+This is a bare metal implementation, so we must have non-blocking functions,
+the process of pumping to serial lines can result a bit slow and we don't want to busy wait.
+This function starts the process, you will call sendPacketBuffernb() until it reports success (or error)
+*/
+void transport_sendPacketBuffernb_start(int sock, unsigned char* buf, int buflen);
+/**
+This is a bare metal implementation, so we must have non-blocking functions,
+the process of pumping to serial lines can result a bit slow and we don't want to busy wait
+@returns TRANSPORT_DONE if finished, TRANSPORT_AGAIN for call again, or TRANSPORT_ERROR on error
+@note you will call again until it finishes (this is stream)
+*/
+int transport_sendPacketBuffernb(int sock);
+
+/**
+This is a bare metal implementation, so we must have non-blocking functions,
+the process of sucking from serial lines can result a bit slow and we don't want to busy wait
+@return the actual number of bytes read, 0 for none, or TRANSPORT_ERROR on error
+@note you will call again until total number of expected bytes is read (this is stream)
+*/
+int transport_getdatanb(void *sck, unsigned char* buf, int count);
+
+/**
+We assume whatever connection needs to be done, it is externally established by the specifics of the hardware
+E.g.:
+A cell modem: you will call AT+whatever and put the modem in transparent mode, OR, you will embed
+the AT+xSENDx / AT+xRECVx commands into the former sendPacketBuffer() and getdatanb() functions
+@param	thisio	pointer to a structure containing all necessary stuff to handle direct serial I/O
+@returns	whatever indicator the system assigns to this link, if any. (a.k.a. : 'sock'), or TRANSPORT_ERROR for error
+*/
+int transport_open(transport_iofunctions_t *thisio);
+int transport_close(int sock);


### PR DESCRIPTION
"baremetalserial" is for example a UART on a microcontroller. This transport has been used to move MQTT data to/from a cell modem so it handled TCP stuff with the broker.
The user connects with the cell modem (usually driven by AT commands) in transparent mode, so anything sent to the serial will be sent to the modem and viceversa. The transport interface makes this look like TCP to Paho.
The samples simulate a similar environment using the much more comfortable Linux one, while adding some reallife-like simulations for testing purposes.

