### PR TITLE
Removes unused variable strindex to silence compiler warnings.

### DIFF
--- a/MQTTPacket/src/MQTTFormat.c
+++ b/MQTTPacket/src/MQTTFormat.c
@@ -119,7 +119,6 @@ char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf,
 	int index = 0;
 	int rem_length = 0;
 	MQTTHeader header = {0};
-	int strindex = 0;
 
 	header.byte = buf[index++];
 	index += MQTTPacket_decodeBuf(&buf[index], &rem_length);
@@ -130,7 +129,7 @@ char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf,
 	{
 		unsigned char sessionPresent, connack_rc;
 		if (MQTTDeserialize_connack(&sessionPresent, &connack_rc, buf, buflen) == 1)
-			strindex = MQTTStringFormat_connack(strbuf, strbuflen, connack_rc, sessionPresent);
+			MQTTStringFormat_connack(strbuf, strbuflen, connack_rc, sessionPresent);
 	}
 	break;
 	case PUBLISH:
@@ -141,7 +140,7 @@ char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf,
 		MQTTString topicName = MQTTString_initializer;
 		if (MQTTDeserialize_publish(&dup, &qos, &retained, &packetid, &topicName,
 				&payload, &payloadlen, buf, buflen) == 1)
-			strindex = MQTTStringFormat_publish(strbuf, strbuflen, dup, qos, retained, packetid,
+			MQTTStringFormat_publish(strbuf, strbuflen, dup, qos, retained, packetid,
 					topicName, payload, payloadlen);
 	}
 	break;
@@ -153,7 +152,7 @@ char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf,
 		unsigned char packettype, dup;
 		unsigned short packetid;
 		if (MQTTDeserialize_ack(&packettype, &dup, &packetid, buf, buflen) == 1)
-			strindex = MQTTStringFormat_ack(strbuf, strbuflen, packettype, dup, packetid);
+			MQTTStringFormat_ack(strbuf, strbuflen, packettype, dup, packetid);
 	}
 	break;
 	case SUBACK:
@@ -162,20 +161,20 @@ char* MQTTFormat_toClientString(char* strbuf, int strbuflen, unsigned char* buf,
 		int maxcount = 1, count = 0;
 		int grantedQoSs[1];
 		if (MQTTDeserialize_suback(&packetid, maxcount, &count, grantedQoSs, buf, buflen) == 1)
-			strindex = MQTTStringFormat_suback(strbuf, strbuflen, packetid, count, grantedQoSs);
+			MQTTStringFormat_suback(strbuf, strbuflen, packetid, count, grantedQoSs);
 	}
 	break;
 	case UNSUBACK:
 	{
 		unsigned short packetid;
 		if (MQTTDeserialize_unsuback(&packetid, buf, buflen) == 1)
-			strindex = MQTTStringFormat_ack(strbuf, strbuflen, UNSUBACK, 0, packetid);
+			MQTTStringFormat_ack(strbuf, strbuflen, UNSUBACK, 0, packetid);
 	}
 	break;
 	case PINGREQ:
 	case PINGRESP:
 	case DISCONNECT:
-		strindex = snprintf(strbuf, strbuflen, "%s", MQTTPacket_names[header.bits.type]);
+		snprintf(strbuf, strbuflen, "%s", MQTTPacket_names[header.bits.type]);
 		break;
 	}
 	return strbuf;
@@ -187,7 +186,6 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 	int index = 0;
 	int rem_length = 0;
 	MQTTHeader header = {0};
-	int strindex = 0;
 
 	header.byte = buf[index++];
 	index += MQTTPacket_decodeBuf(&buf[index], &rem_length);
@@ -199,7 +197,7 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 		MQTTPacket_connectData data;
 		int rc;
 		if ((rc = MQTTDeserialize_connect(&data, buf, buflen)) == 1)
-			strindex = MQTTStringFormat_connect(strbuf, strbuflen, &data);
+			MQTTStringFormat_connect(strbuf, strbuflen, &data);
 	}
 	break;
 	case PUBLISH:
@@ -210,7 +208,7 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 		MQTTString topicName = MQTTString_initializer;
 		if (MQTTDeserialize_publish(&dup, &qos, &retained, &packetid, &topicName,
 				&payload, &payloadlen, buf, buflen) == 1)
-			strindex = MQTTStringFormat_publish(strbuf, strbuflen, dup, qos, retained, packetid,
+			MQTTStringFormat_publish(strbuf, strbuflen, dup, qos, retained, packetid,
 					topicName, payload, payloadlen);
 	}
 	break;
@@ -222,7 +220,7 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 		unsigned char packettype, dup;
 		unsigned short packetid;
 		if (MQTTDeserialize_ack(&packettype, &dup, &packetid, buf, buflen) == 1)
-			strindex = MQTTStringFormat_ack(strbuf, strbuflen, packettype, dup, packetid);
+			MQTTStringFormat_ack(strbuf, strbuflen, packettype, dup, packetid);
 	}
 	break;
 	case SUBSCRIBE:
@@ -234,7 +232,7 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 		int requestedQoSs[1];
 		if (MQTTDeserialize_subscribe(&dup, &packetid, maxcount, &count,
 				topicFilters, requestedQoSs, buf, buflen) == 1)
-			strindex = MQTTStringFormat_subscribe(strbuf, strbuflen, dup, packetid, count, topicFilters, requestedQoSs);;
+			MQTTStringFormat_subscribe(strbuf, strbuflen, dup, packetid, count, topicFilters, requestedQoSs);;
 	}
 	break;
 	case UNSUBSCRIBE:
@@ -244,13 +242,13 @@ char* MQTTFormat_toServerString(char* strbuf, int strbuflen, unsigned char* buf,
 		int maxcount = 1, count = 0;
 		MQTTString topicFilters[1];
 		if (MQTTDeserialize_unsubscribe(&dup, &packetid, maxcount, &count, topicFilters, buf, buflen) == 1)
-			strindex =  MQTTStringFormat_unsubscribe(strbuf, strbuflen, dup, packetid, count, topicFilters);
+			MQTTStringFormat_unsubscribe(strbuf, strbuflen, dup, packetid, count, topicFilters);
 	}
 	break;
 	case PINGREQ:
 	case PINGRESP:
 	case DISCONNECT:
-		strindex = snprintf(strbuf, strbuflen, "%s", MQTTPacket_names[header.bits.type]);
+		snprintf(strbuf, strbuflen, "%s", MQTTPacket_names[header.bits.type]);
 		break;
 	}
 	strbuf[strbuflen] = '\0';


### PR DESCRIPTION
Removing unused references to strindex variable to get rid of compiler warnings.