### PR TITLE
check keepalive return value in cycle() to know its failure

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -281,7 +281,12 @@ int cycle(MQTTClient* c, Timer* timer)
             c->ping_outstanding = 0;
             break;
     }
-    keepalive(c);
+
+    if(keepalive(c) != SUCCESS) {
+        //check only keepalive FAILURE status so that previous FAILURE status can be considered as FAULT
+        rc = FAILURE;
+    }
+
 exit:
     if (rc == SUCCESS && packet_type != FAILURE)
         rc = packet_type;


### PR DESCRIPTION
Signed-off-by: Steve Song <sshtel@gmail.com>


In cycle() of MQTTClient.c, there is a function call to check keepalive message.
Although keepalive time is expired, its status is not being checked and still cycle() returns SUCCESS