### PR TITLE
Fixed QOS2 when QOS1 and QOS2 are both defined

### DIFF
--- a/MQTTClient/src/MQTTClient.h
+++ b/MQTTClient/src/MQTTClient.h
@@ -838,7 +838,8 @@ int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, b>::publish(int len, Time
         else
             rc = FAILURE;
     }
-#elif MQTTCLIENT_QOS2
+#endif
+#if MQTTCLIENT_QOS2
     else if (qos == QOS2)
     {
         if (waitfor(PUBCOMP, timer) == PUBCOMP)


### PR DESCRIPTION
This will fix QOS2 in CPP library, when both MQTTCLIENT_QOS1 and MQTTCLIENT_QOS2 are defined.
The original source didn't allow to compile the code from line 841 to 854.
