### PR TITLE
Add #include "string.h" to declare 'strcmp'

### DIFF
--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -36,6 +36,7 @@
 
 #include "MQTTPacket.h"
 #include "stdio.h"
+#include "string.h"
 
 #if defined(MQTTCLIENT_PLATFORM_HEADER)
 /* The following sequence of macros converts the MQTTCLIENT_PLATFORM_HEADER value


### PR DESCRIPTION
Resolves #113 

-Wall on my platform yields

paho.mqtt.embedded-c/MQTTClient-C/src/MQTTClient.c:475:9:
warning: implicit declaration of function 'strcmp'
[-Wimplicit-function-declaration]

While likely innocuous, this eases overall development

"string.h" form chosen over <string.h> for consistency
with other #include directives in the project