### PR TITLE
Linker conflicting declarations for MQTTIsConnected() fix.

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -358,6 +358,10 @@ int MQTTYield(MQTTClient* c, int timeout_ms)
     return rc;
 }
 
+int MQTTIsConnected(MQTTClient* client)
+{
+  return client->isconnected;
+}
 
 void MQTTRun(void* parm)
 {

--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -216,10 +216,7 @@ DLLExport int MQTTYield(MQTTClient* client, int time);
  *  @param client - the client object to use
  *  @return truth value indicating whether the client is connected to the server
  */
-DLLExport int MQTTIsConnected(MQTTClient* client)
-{
-  return client->isconnected;
-}
+DLLExport int MQTTIsConnected(MQTTClient* client);
 
 #if defined(MQTT_TASK)
 /** MQTT start background thread for a client.  After this, MQTTYield should not be called.

--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -16,8 +16,8 @@
  *    Ian Craggs - add setMessageHandler function
  *******************************************************************************/
 
-#if !defined(__MQTT_CLIENT_C_)
-#define __MQTT_CLIENT_C_
+#if !defined(MQTT_CLIENT_H)
+#define MQTT_CLIENT_H
 
 #if defined(__cplusplus)
  extern "C" {


### PR DESCRIPTION
Sample issue in Microchip XC8 compiler & linker:
----------------------------------------------------------
Microchip MPLAB XC8 C Compiler (Free Mode) V1.44
Build date: Sep 13 2017
Part Support Version: 1.44
Copyright (C) 2017 Microchip Technology Inc.
License type: Node Configuration

app_files/pic-tcpip/paho.mqtt.embedded-c-master/MQTTClient-C/MQTTClient.h:221: error: (1098) conflicting declarations for variable "_MQTTIsConnected" (app_files/pic-tcpip/paho.mqtt.embedded-c-master/MQTTClient-C/MQTTClient.h:221)
(908) exit status = 1
  