### PR TITLE
Update MQTTLinux.c

### DIFF
--- a/MQTTClient-C/src/linux/MQTTLinux.c
+++ b/MQTTClient-C/src/linux/MQTTLinux.c
@@ -154,6 +154,8 @@ int NetworkConnect(Network* n, char* addr, int port)
 		n->my_socket = socket(family, type, 0);
 		if (n->my_socket != -1)
 			rc = connect(n->my_socket, (struct sockaddr*)&address, sizeof(address));
+		else
+			rc = -1;
 	}
 
 	return rc;


### PR DESCRIPTION
for issue #123.

in the function NetworkConnect. if creating a socket fails,value n->my_socket is -1, the function connect is not executed. so the function will return success directly.