### PR TITLE
Fix for #147, where NetworkConnect cannot connect on FreeRTOS when an…

### DIFF
--- a/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
+++ b/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
@@ -156,7 +156,7 @@ int NetworkConnect(Network* n, char* addr, int port)
 	struct freertos_sockaddr sAddr;
 	int retVal = -1;
 
-	// FreeRTOS_gethostbyname does not check if its the addr is already
+	// FreeRTOS_gethostbyname does not check if addr is already
 	// an IP address so do that first, otherwise valid IP addresses will fail.
 	sAddr.sin_addr = FreeRTOS_inet_addr( addr );
 	if ( sAddr.sin_addr == 0 )

--- a/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
+++ b/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
@@ -155,13 +155,22 @@ int NetworkConnect(Network* n, char* addr, int port)
 {
 	struct freertos_sockaddr sAddr;
 	int retVal = -1;
-	uint32_t ipAddress;
 
-	if ((ipAddress = FreeRTOS_gethostbyname(addr)) == 0)
-		goto exit;
+	// FreeRTOS_gethostbyname does not check if its the addr is already
+	// an IP address so do that first, otherwise valid IP addresses will fail.
+	sAddr.sin_addr = FreeRTOS_inet_addr( addr );
+	if ( sAddr.sin_addr == 0 )
+	{
+		// addr was not a valid IP address so do a lookup.
+		sAddr.sin_addr = FreeRTOS_gethostbyname(addr);
+		if ( sAddr.sin_addr == 0 )
+		{
+			// Lookup failed.
+			goto exit;
+		}
+	}
 
 	sAddr.sin_port = FreeRTOS_htons(port);
-	sAddr.sin_addr = ipAddress;
 
 	if ((n->my_socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_STREAM, FREERTOS_IPPROTO_TCP)) < 0)
 		goto exit;

--- a/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
+++ b/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
@@ -175,6 +175,10 @@ int NetworkConnect(Network* n, char* addr, int port)
 	if ((n->my_socket = FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_STREAM, FREERTOS_IPPROTO_TCP)) < 0)
 		goto exit;
 
+	// Set a timeout so the connect does not hang forever if the socket is in close_wait
+	uint32_t tmo = 2000;
+	FreeRTOS_setsockopt( n->my_socket, 1, FREERTOS_SO_RCVTIMEO, (void *)&tmo, sizeof(uint32_t) );
+
 	if ((retVal = FreeRTOS_connect(n->my_socket, &sAddr, sizeof(sAddr))) < 0)
 	{
 		FreeRTOS_closesocket(n->my_socket);


### PR DESCRIPTION
Fix for #147 where if IP address is specified in the addr string to NetworkConnect on FreeRTOS and there is no DNS server specified, the connect fails.

Signed-off-by: igough <igough57@gmail.com>