### PR TITLE
Fix spurious timeout problems with C client.

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -74,6 +74,7 @@ void MQTTClientInit(MQTTClient* c, Network* network, unsigned int command_timeou
 	  c->next_packetid = 1;
     TimerInit(&c->last_sent);
     TimerInit(&c->last_received);
+    TimerInit(&c->pingresp_timer);
 #if defined(MQTT_TASK)
 	  MutexInit(&c->mutex);
 #endif
@@ -216,18 +217,28 @@ int keepalive(MQTTClient* c)
     if (c->keepAliveInterval == 0)
         goto exit;
 
-    if (TimerIsExpired(&c->last_sent) || TimerIsExpired(&c->last_received))
-    {
-        if (c->ping_outstanding)
+    // If we are waiting for a ping response, check if it has been too long
+    if ( c->ping_outstanding == 1 ){
+        if ( TimerIsExpired(&c->pingresp_timer) ){
             rc = FAILURE; /* PINGRESP not received in keepalive interval */
-        else
+            goto exit;
+        }
+    } else {
+        // If we have not sent or received anything in the timeout period,
+        // send out a ping request
+        if ( TimerIsExpired(&c->last_sent) || TimerIsExpired(&c->last_received) )
         {
             Timer timer;
             TimerInit(&timer);
             TimerCountdownMS(&timer, 1000);
             int len = MQTTSerialize_pingreq(c->buf, c->buf_size);
-            if (len > 0 && (rc = sendPacket(c, len, &timer)) == SUCCESS) // send the ping packet
+            if (len > 0 && (rc = sendPacket(c, len, &timer)) == SUCCESS){
+                // send the ping packet
+                // Expect the PINGRESP within 2 seconds of the PINGREQ
+                // being sent
+                TimerCountdownMS(&c->pingresp_timer, 2000 );
                 c->ping_outstanding = 1;
+            }
         }
     }
 

--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -124,7 +124,7 @@ typedef struct MQTTClient
     void (*defaultMessageHandler) (MessageData*);
 
     Network* ipstack;
-    Timer last_sent, last_received;
+  Timer last_sent, last_received, pingresp_timer;
 #if defined(MQTT_TASK)
     Mutex mutex;
     Thread thread;


### PR DESCRIPTION
Using the C client for FreeRTOS, with keep-alive set to 4 seconds, I noticed that the client experiences spurious timeouts. I have tracked this down to keepalive().

```
int keepalive(MQTTClient* c)
{
  int rc = SUCCESS;

    if (c->keepAliveInterval == 0)
        goto exit;

    if (TimerIsExpired(&c->last_sent) || TimerIsExpired(&c->last_received))
    {
        if (c->ping_outstanding){
        	printf( "keepalive: PINGRESP maybe not received\n" );
            rc = FAILURE; /* PINGRESP not received in keepalive interval */
        }
        else
        {
            Timer timer;
            TimerInit(&timer);
            TimerCountdownMS(&timer, 1000);
            int len = MQTTSerialize_pingreq(c->buf, c->buf_size);
            if (len > 0 && (rc = sendPacket(c, len, &timer)) == SUCCESS){ // send the ping packet
            	printf( "keepalive: sending PINGREQ\n" );
            	c->ping_outstanding = 1;
            }
        }
    }

exit:
    return rc;
}
```

I have discovered a scenario in which `timeout()` returns `FAILURE` when it should not, which is interpreted as a client-side timeout which closes the connection to the broker. The following are preconditions:
1. Client node does not receive messages very often.
2. Client node emits messages slower than the keep-alive time.
3. c->keepAliveInterval is set low (to 4 seconds).
The scenario is:
1. Client publishes a message. This starts the last_sent timer.
2. Time passes and timeout() is run from cycle() and recognizes a last_sent timeout. This causes the Client to publish a PINGREQ, This restarts the last_sent timer and sets ping_outstanding to 1.
3. Client receives a PINGRESP. This starts the last_received timer and clears ping_outstanding to 0.
4.  Time passes and timeout() is run from cycle() and recognizes a last_sent timeout. This causes the Client to publish a PINGREQ, This restarts the last_sent timer and sets ping_outstanding to 1. 
5. The PINGRESP is slighly delayed due to network jitter
6. timeout() is run from cycle() and recognizes a last_received timeout since the PINGRESP this time took a couple of milliseconds longer than the PINGRESP last time. In timeout(), the ping_outstanding is checked and it is set to 1 from the ping that was issued milliseconds previously. timeout() interprets this as a real timeout, when it really is not.

The MQTT spec says 

> If a Client does not receive a PINGRESP Packet within a reasonable amount of time after it has sent a PINGREQ, it SHOULD close the Network Connection to the Server.

The code for this PR sets a 2 second timer after the PINGREQ is sent and if the response is not received within this period, returns FAILURE from timeout(). This code changes the behaviour such that rather than experiencing spurious timeouts once within a 1/2 hr period, there were no timeouts over an 11 hour period. The test would have run longer, but there was a city-wide power outage that stopped the test.