### PR TITLE
fix memcpy/strcmp not declared in this scope

### DIFF
--- a/MQTTClient/src/MQTTClient.h
+++ b/MQTTClient/src/MQTTClient.h
@@ -26,7 +26,7 @@
 
 #include "FP.h"
 #include "MQTTPacket.h"
-#include <stdio.h>
+#include <string.h>
 #include "MQTTLogging.h"
 
 #if !defined(MQTTCLIENT_QOS1)


### PR DESCRIPTION
compiling with g++ results in a failure to find the declarations of memcpy and strcmp.  This replaces the unused include <stdio.h> with <string.h> to add those declarations.