### PR TITLE
Add REVERSED bitfield definition for big endian processors #170

### DIFF
--- a/MQTTPacket/src/MQTTConnect.h
+++ b/MQTTPacket/src/MQTTConnect.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corp.
+ * Copyright (c) 2014, 2019 IBM Corp.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,6 +35,13 @@ enum connack_return_codes
 #endif
 #if !defined(DLLExport)
   #define DLLExport
+#endif
+
+#if defined(__linux__)
+#include <endian.h>
+#if __BYTE_ORDER == __BIG_ENDIAN
+	#define REVERSED 1
+#endif
 #endif
 
 

--- a/MQTTPacket/src/MQTTPacket.h
+++ b/MQTTPacket/src/MQTTPacket.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corp.
+ * Copyright (c) 2014, 2019 IBM Corp.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
  * Contributors:
  *    Ian Craggs - initial API and implementation and/or initial documentation
  *    Xiang Rong - 442039 Add makefile to Embedded C client
+ *    Ian Craggs - big endian Linux reversed definition
  *******************************************************************************/
 
 #ifndef MQTTPACKET_H_
@@ -32,6 +33,14 @@ extern "C" {
   #define DLLImport
   #define DLLExport  
 #endif
+
+#if defined(__linux__)
+#include <endian.h>
+#if __BYTE_ORDER == __BIG_ENDIAN
+	#define REVERSED 1
+#endif
+#endif
+
 
 enum errors
 {


### PR DESCRIPTION
Similar to paho.mqtt.c project, attempt to connect from a big endian platform would fail. Applied 862b1d3 from paho.mqtt.c.

Signed-off-by: Frédéric Nadeau <fred.nadeau@gmail.com>