### PR TITLE
Topic match Bug Fix

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -172,7 +172,7 @@ static char isTopicMatched(char* topicFilter, MQTTString* topicName)
         curn++;
     };
 
-    return (curn == curn_end) && (*curf == '\0');
+    return (curn == curn_end) && (*curf == '\0' || *curf == '#');
 }
 
 


### PR DESCRIPTION
If the client subscribes to the topic "TESTtopic/#" and a message is sent on to the topic "TESTtopic/" then the library does not consider it as a valid topic match. This pull would fix it.