### PR TITLE
mqttwrite() the corrected number of bytes in sendPacket()

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -38,7 +38,7 @@ static int sendPacket(MQTTClient* c, int length, Timer* timer)
 
     while (sent < length && !TimerIsExpired(timer))
     {
-        rc = c->ipstack->mqttwrite(c->ipstack, &c->buf[sent], length, TimerLeftMS(timer));
+        rc = c->ipstack->mqttwrite(c->ipstack, &c->buf[sent], length - sent, TimerLeftMS(timer));
         if (rc < 0)  // there was an error writing the data
             break;
         sent += rc;


### PR DESCRIPTION
More info on the issue:
https://github.com/eclipse/paho.mqtt.embedded-c/issues/177
