### PR TITLE
Add error on undefined MQTTCLIENT_PLATFORM_HEADER

### DIFF
--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -43,6 +43,8 @@
 #define xstr(s) str(s)
 #define str(s) #s
 #include xstr(MQTTCLIENT_PLATFORM_HEADER)
+#else
+#error "Define MQTTCLIENT_PLATFORM_HEADER first!"
 #endif
 
 #define MAX_PACKET_ID 65535 /* according to the MQTT specification - do not change! */


### PR DESCRIPTION
I think it would be better to show a proper error message when a user just starts and tries to compile the lib