### PR TITLE
docs: fix simple typo, nework -> network

### DIFF
--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -145,7 +145,7 @@ DLLExport void MQTTClientInit(MQTTClient* client, Network* network, unsigned int
 		unsigned char* sendbuf, size_t sendbuf_size, unsigned char* readbuf, size_t readbuf_size);
 
 /** MQTT Connect - send an MQTT connect packet down the network and wait for a Connack
- *  The nework object must be connected to the network endpoint before calling this
+ *  The network object must be connected to the network endpoint before calling this
  *  @param options - connect options
  *  @return success code
  */
@@ -153,7 +153,7 @@ DLLExport int MQTTConnectWithResults(MQTTClient* client, MQTTPacket_connectData*
     MQTTConnackData* data);
 
 /** MQTT Connect - send an MQTT connect packet down the network and wait for a Connack
- *  The nework object must be connected to the network endpoint before calling this
+ *  The network object must be connected to the network endpoint before calling this
  *  @param options - connect options
  *  @return success code
  */


### PR DESCRIPTION
There is a small typo in MQTTClient-C/src/MQTTClient.h.

Should read `network` rather than `nework`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md