### PR TITLE
Make sure QoS enum is compiled as int

### DIFF
--- a/MQTTClient/src/MQTTClient.h
+++ b/MQTTClient/src/MQTTClient.h
@@ -41,7 +41,7 @@ namespace MQTT
 {
 
 
-enum QoS { QOS0, QOS1, QOS2 };
+enum QoS: int { QOS0, QOS1, QOS2 };
 
 // all failure return codes must be negative
 enum returnCode { BUFFER_OVERFLOW = -2, FAILURE = -1, SUCCESS = 0 };


### PR DESCRIPTION
Let me start by thanking the authors for creating this great library :)

This pull request is somewhat related to #94 and #169 and makes sure the QoS enum is compiled as an int. In my case the compiler compiles it as a char. It could possibly also be fixed by changing my compiler configuration, but this seems like a small update that makes sure it compiles correctly.