### PR TITLE
For issue #223

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -43,7 +43,7 @@ static int sendPacket(MQTTClient* c, int length, Timer* timer)
     }
     while (sent < length && !TimerIsExpired(timer))
     {
-        rc = c->ipstack->mqttwrite(c->ipstack, &c->buf[sent], length, TimerLeftMS(timer));
+        rc = c->ipstack->mqttwrite(c->ipstack, &c->buf[sent], length - sent, TimerLeftMS(timer));
         if (rc < 0)  // there was an error writing the data
             break;
         sent += rc;

--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -36,6 +36,11 @@ static int sendPacket(MQTTClient* c, int length, Timer* timer)
     int rc = FAILURE,
         sent = 0;
 
+    if(TimerLeftMS(timer) < MIN_SEND_PACKET_TIMEOUT_MS)
+    {
+        TimerInit(timer);
+        TimerCountdownMS(timer, MIN_SEND_PACKET_TIMEOUT_MS);
+    }
     while (sent < length && !TimerIsExpired(timer))
     {
         rc = c->ipstack->mqttwrite(c->ipstack, &c->buf[sent], length, TimerLeftMS(timer));

--- a/MQTTClient-C/src/MQTTClient.h
+++ b/MQTTClient-C/src/MQTTClient.h
@@ -51,6 +51,10 @@
 #define MAX_MESSAGE_HANDLERS 5 /* redefinable - how many subscriptions do you want? */
 #endif
 
+#if !defined(MIN_SEND_PACKET_TIMEOUT_MS)
+#define MIN_SEND_PACKET_TIMEOUT_MS 50 /* redefinable - minimal send timeout? */
+#endif
+
 enum QoS { QOS0, QOS1, QOS2, SUBFAIL=0x80 };
 
 /* all failure return codes must be negative */


### PR DESCRIPTION
- In the sendPacket() function, when timer is expired mqttwrite() function is not excute. So to give it a change to send ack packet (issue #223), we need to define a minimal timeout
- The send packet timeout is defined by MIN_SEND_PACKET_TIMEOUT_MS macro