### PR TITLE
fix mqtt5 user property error, string pair should not use type of union.

### DIFF
--- a/MQTTPacket/src/V5/MQTTProperties.c
+++ b/MQTTPacket/src/V5/MQTTProperties.c
@@ -117,8 +117,8 @@ int MQTTProperties_add(MQTTProperties* props, MQTTProperty* prop)
         len = 2 + prop->value.data.len;
         break;
       case UTF_8_STRING_PAIR:
-        len = 2 + prop->value.data.len;
-        len += 2 + prop->value.value.len;
+        len = 2 + prop->value.string_pair.key.len;
+        len += 2 + prop->value.string_pair.val.len;
         break;
     }
     props->length += len + 1; /* add identifier byte */
@@ -160,9 +160,9 @@ int MQTTProperty_write(unsigned char** pptr, MQTTProperty* prop)
         rc = prop->value.data.len + 2; /* include length field */
         break;
       case UTF_8_STRING_PAIR:
-        writeMQTTLenString(pptr, prop->value.data);
-        writeMQTTLenString(pptr, prop->value.value);
-        rc = prop->value.data.len + prop->value.value.len + 4; /* include length fields */
+        writeMQTTLenString(pptr, prop->value.string_pair.key);
+        writeMQTTLenString(pptr, prop->value.string_pair.val);
+        rc = prop->value.string_pair.key.len + prop->value.string_pair.val.len + 4; /* include length fields */
         break;
     }
   }
@@ -231,8 +231,8 @@ int MQTTProperty_read(MQTTProperty* prop, unsigned char** pptr, unsigned char* e
         len = MQTTLenStringRead(&prop->value.data, pptr, enddata);
         break;
       case UTF_8_STRING_PAIR:
-        len = MQTTLenStringRead(&prop->value.data, pptr, enddata);
-        len += MQTTLenStringRead(&prop->value.value, pptr, enddata);
+        len = MQTTLenStringRead(&prop->value.string_pair.key, pptr, enddata);
+        len += MQTTLenStringRead(&prop->value.string_pair.val, pptr, enddata);
         break;
     }
   }

--- a/MQTTPacket/src/V5/MQTTProperties.h
+++ b/MQTTPacket/src/V5/MQTTProperties.h
@@ -55,6 +55,10 @@ enum PropertyTypes {
   UTF_8_STRING_PAIR
 };
 
+typedef struct {
+  MQTTLenString key;
+  MQTTLenString val;
+} MQTTStringPair;
 
 typedef struct
 {
@@ -64,7 +68,7 @@ typedef struct
     short integer2;
     int integer4;
     MQTTLenString data;
-    MQTTLenString value; /* for user properties */
+    MQTTStringPair string_pair; /* for user properties */
   } value;
 } MQTTProperty;
 

--- a/MQTTPacket/test/test2.c
+++ b/MQTTPacket/test/test2.c
@@ -533,10 +533,10 @@ int test3(struct Options options)
 
 	MQTTProperty one;
 	one.identifier = USER_PROPERTY;
-	one.value.data.data = "user property name";
-	one.value.data.len = strlen(one.value.data.data) + 1;
-	one.value.value.data = "user property value";
-	one.value.value.len = strlen(one.value.value.data) + 1;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
 	rc = MQTTProperties_add(&properties, &one);
 
 	fprintf(xml, "<testcase classname=\"test3\" name=\"de/serialization\"");
@@ -617,10 +617,10 @@ int test4(struct Options options)
 
 	MQTTProperty one;
 	one.identifier = USER_PROPERTY;
-	one.value.data.data = "user property name";
-	one.value.data.len = strlen(one.value.data.data) + 1;
-	one.value.value.data = "user property value";
-	one.value.value.len = strlen(one.value.value.data) + 1;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
 	rc = MQTTProperties_add(&properties, &one);
 
 	fprintf(xml, "<testcase classname=\"test4\" name=\"de/serialization\"");
@@ -682,10 +682,10 @@ int test5(struct Options options)
 
 	MQTTProperty one;
 	one.identifier = USER_PROPERTY;
-	one.value.data.data = "user property name";
-	one.value.data.len = strlen(one.value.data.data) + 1;
-	one.value.value.data = "user property value";
-	one.value.value.len = strlen(one.value.value.data) + 1;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
 	rc = MQTTProperties_add(&properties, &one);
 
 	fprintf(xml, "<testcase classname=\"test5\" name=\"de/serialization\"");
@@ -850,10 +850,10 @@ int test8(struct Options options)
 
 	MQTTProperty one;
 	one.identifier = USER_PROPERTY;
-	one.value.data.data = "user property name";
-	one.value.data.len = strlen(one.value.data.data) + 1;
-	one.value.value.data = "user property value";
-	one.value.value.len = strlen(one.value.value.data) + 1;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
 	rc = MQTTProperties_add(&properties, &one);
 
 	fprintf(xml, "<testcase classname=\"test8\" name=\"de/serialization\"");
@@ -904,10 +904,10 @@ int test9(struct Options options)
 
 	MQTTProperty one;
 	one.identifier = USER_PROPERTY;
-	one.value.data.data = "user property name";
-	one.value.data.len = strlen(one.value.data.data) + 1;
-	one.value.value.data = "user property value";
-	one.value.value.len = strlen(one.value.value.data) + 1;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
 	rc = MQTTProperties_add(&properties, &one);
 
 	fprintf(xml, "<testcase classname=\"test9\" name=\"de/serialization\"");

--- a/MQTTPacket/test/test3.c
+++ b/MQTTPacket/test/test3.c
@@ -277,6 +277,15 @@ int test1(struct Options options)
 	one.identifier = SESSION_EXPIRY_INTERVAL;
 	one.value.integer4 = 45;
 	rc = MQTTProperties_add(&properties, &one);
+	assert("add properties rc should be 0",  rc == 0, "rc was different %d\n", rc);
+
+	one.identifier = USER_PROPERTY;
+	one.value.string_pair.key.data = "user property name";
+	one.value.string_pair.key.len = strlen(one.value.string_pair.key.data) + 1;
+	one.value.string_pair.val.data = "user property value";
+	one.value.string_pair.val.len = strlen(one.value.string_pair.val.data) + 1;
+	rc = MQTTProperties_add(&properties, &one);
+	assert("add properties rc should be 0",  rc == 0, "rc was different %d\n", rc);
 
 	len = MQTTV5Serialize_connect((unsigned char *)buf, buflen, &data, &properties, NULL);
 	rc = transport_sendPacketBuffer(mysock, buf, len);


### PR DESCRIPTION
when we use type union to store the string pair, the key and value of string pair will be the same.