### PR TITLE
bug Fix: Resolved an issue where, due to some compilers defaulting to signed char type and assigning signed char type to int type, the judgment was always unequal when ported to this hardware platform for runtime. Fix: Resolved an issue where, due to some compilers defaulting to…

### DIFF
--- a/MQTTClient-C/src/MQTTClient.c
+++ b/MQTTClient-C/src/MQTTClient.c
@@ -545,7 +545,7 @@ int MQTTSubscribeWithResults(MQTTClient* c, const char* topicFilter, enum QoS qo
         data->grantedQoS = QOS0;
         if (MQTTDeserialize_suback(&mypacketid, 1, &count, (int*)&data->grantedQoS, c->readbuf, c->readbuf_size) == 1)
         {
-            if (data->grantedQoS != 0x80)
+            if ((unsigned char)data->grantedQoS != 0x80)
                 rc = MQTTSetMessageHandler(c, topicFilter, messageHandler);
         }
     }


### PR DESCRIPTION
bug Fix: Resolved an issue where, due to some compilers defaulting to signed char type and assigning signed char type to int type, the judgment was always unequal when ported to this hardware platform for runtime.